### PR TITLE
feat: Implement coupon reservation functionality

### DIFF
--- a/lib/controller/coupon_reserve_controller.dart
+++ b/lib/controller/coupon_reserve_controller.dart
@@ -5,8 +5,8 @@ import 'package:get_storage/get_storage.dart';
 
 import '../util/app_vars.dart';
 
-class SignInController extends GetxController {
-  static const String uri = "/api/coupons/reserve";
+class CouponReserveController extends GetxController {
+  static const String uri = "/api/coupons/reserve/";
 
   bool loading = false;
 
@@ -15,34 +15,44 @@ class SignInController extends GetxController {
     update();
   }
 
-  Future<Map<String, dynamic>?> postServerData(
-      {Map<String, dynamic>? params}) async {
+  Future<bool> postServerData(
+      {required String code,
+      required int userId,
+      required int teacherId,
+      required int subjectId}) async {
     isLoading(loading: true);
     try {
+      final Map<String, dynamic> requestBody = {
+        "code": code,
+        "user_id": userId,
+        "teacher_id": teacherId,
+        "subject_id": subjectId
+      };
       final responseMap = await AppVars.api.post(
         uri,
-        params: params ?? {},
+        params: requestBody,
       );
       print("response $responseMap");
-      if (responseMap != null) {
-        GetStorage().write("token", responseMap["token"]);
-        final Map<String, dynamic>? response = responseMap["user"];
-        if (response != null) {
-          Fluttertoast.showToast(
-            msg: "تم تسجيل الدخول بنجاح",
-          );
-          isLoading(loading: false);
-          return response;
+      if (responseMap != null && responseMap["error"] == null) {
+        Fluttertoast.showToast(msg: "تم حجز الكوبون بنجاح");
+        isLoading(loading: false);
+        return true;
+      } else {
+        String errorMessage = "فشل حجز الكوبون";
+        if (responseMap != null && responseMap["message"] != null) {
+          errorMessage += ": ${responseMap["message"]}";
         }
+        Fluttertoast.showToast(msg: errorMessage);
+        isLoading(loading: false);
+        return false;
       }
     } catch (err) {
       if (kDebugMode) print("err $uri: $err");
       Fluttertoast.showToast(
-        msg: "حدث خطأ ما ${err}",
+        msg: "فشل حجز الكوبون: ${err}",
       );
       isLoading(loading: false);
-      return null;
+      return false;
     }
-    return null;
   }
 }

--- a/lib/util/app_consts.dart
+++ b/lib/util/app_consts.dart
@@ -5,6 +5,7 @@ class AppConsts {
   static const String baseUrl = "https://sharq.afkarsoft.xyz";
   // static const String baseUrl = "http://172.16.4.249";
   static const String storageUrl = "/storage";
+  static const String reserveCouponUrl = "/api/coupons/reserve/";
 
   static const String serverToken = "AAAAxI7JdhA:APA91bHwUcmS3U40QQ1ZHW1zabKEs0XZ4apekaN0vv6LLYjlMjje0zdIizJlfZxnPo2J-BQffRY_L3wvgxFnUwHKq1J3jjtmbOhlS6_5jsLZ9W3io1fG8GCT6SvJkoCFjhftPULsqi5l";
   static const String subscribeFCM = "subscribe";


### PR DESCRIPTION
This commit introduces the feature to allow you to enter a coupon code when selecting a lesson.

Key changes:
- Modified `CouponReserveController` (formerly `SignInController`) to handle the POST request to `/api/coupons/reserve/`. The controller now specifically manages coupon reservation logic, including parameters for code, user_id, teacher_id, and subject_id.
- Updated the `Lessons` view (`lib/view/lessons.dart`) to display a dialog prompting for a coupon code when a lesson is tapped.
  - You can enter a coupon and attempt to reserve it.
  - You can skip the coupon entry.
  - Navigation to `EducationTools` occurs after successful reservation or skipping.
- Added the `reserveCouponUrl` constant in `lib/util/app_consts.dart`.

Manual testing is required to verify the end-to-end coupon reservation flow, including UI interactions and API responses for various scenarios (valid code, invalid code, already used code, etc.).